### PR TITLE
Fix bugs

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -231,6 +231,11 @@ export const passwordFormValidation = (form: { [key: string]: string }) => {
     } else {
         errorObject['repeatNewPassword']['isSame'] = ''
     }
+    if ([form.currentPassword].includes(form.newPassword)) {
+        errorObject['newPassword']['isPrevious'] = 'La nueva contraseña no puede ser igual a la anterior.'
+    } else {
+        errorObject['newPassword']['isPrevious'] = ''
+    }
     return errorObject
 }
 


### PR DESCRIPTION
- Send the previous password in change-password endpoint payload request.
- Validate API response:
   - Adding trycatch block for safe error handling
   - Getting endpoint messages and display in toast.
- Saving new password in local for auto login
- Clear form when operation is success